### PR TITLE
Item and Level Unlock

### DIFF
--- a/src/PolyGone/Core/Game1.cs
+++ b/src/PolyGone/Core/Game1.cs
@@ -42,6 +42,8 @@ public class Game1 : Game
 
         // Load purchase tracker before any scene that might need it
         PurchaseTracker.Load();
+        // Load item unlock data
+        UnlockTracker.Load();
 
         sceneManager.AddScene(new GameScene(Content, sceneManager, _graphics));
         sceneManager.AddScene(new MenuScene(Content, sceneManager, _graphics));

--- a/src/PolyGone/Core/UnlockTracker.cs
+++ b/src/PolyGone/Core/UnlockTracker.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+namespace PolyGone;
+
+/// <summary>
+/// Tracks which levels the player has completed and derives item unlock status from that.
+/// Data is persisted to a local JSON file in the user's application-data folder.
+/// </summary>
+public static class UnlockTracker
+{
+    private static readonly string SavePath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "PolyGone",
+        "unlocks.json");
+
+    private static HashSet<string> _completedLevels = new();
+
+    /// <summary>
+    /// Maps each locked item to the level name that must be completed to unlock it.
+    /// Items not listed here are always unlocked.
+    /// </summary>
+    private static readonly Dictionary<ItemType, string> _itemUnlockRequirements = new()
+    {
+        { ItemType.HealingGlow, "TestLevel"  },
+        { ItemType.MultiShot,   "TestLevel"  },
+        { ItemType.RapidFire,   "TestLevel2" },
+        { ItemType.LowGravity,  "TestLevel2" },
+        { ItemType.IronWill,    "TestLevel3" },
+    };
+
+    /// <summary>
+    /// The ordered list of level file names. Index 0 is always unlocked;
+    /// every subsequent level requires the one before it to be completed.
+    /// </summary>
+    private static readonly string[] _levelOrder = { "TestLevel", "TestLevel2", "TestLevel3" };
+
+    /// <summary>Returns true if the level is available to play.</summary>
+    public static bool IsLevelUnlocked(string levelFile)
+    {
+        int idx = Array.IndexOf(_levelOrder, levelFile);
+        if (idx <= 0) return true; // first level (or unknown) always unlocked
+        return _completedLevels.Contains(_levelOrder[idx - 1]);
+    }
+
+    /// <summary>Returns a human-readable hint for a locked level, or null if unlocked.</summary>
+    public static string? GetLevelUnlockHint(string levelFile)
+    {
+        int idx = Array.IndexOf(_levelOrder, levelFile);
+        if (idx <= 0) return null;
+        if (_completedLevels.Contains(_levelOrder[idx - 1])) return null;
+        return $"Complete {GetLevelDisplayName(_levelOrder[idx - 1])} to unlock";
+    }
+
+    /// <summary>Returns true if the item is available for selection.</summary>
+    public static bool IsItemUnlocked(ItemType item)
+    {
+        if (!_itemUnlockRequirements.TryGetValue(item, out var requiredLevel))
+            return true; // No requirement — always unlocked
+        return _completedLevels.Contains(requiredLevel);
+    }
+
+    /// <summary>
+    /// Returns a human-readable hint describing how to unlock the item,
+    /// or null if the item is always unlocked.
+    /// </summary>
+    public static string? GetUnlockHint(ItemType item)
+    {
+        if (!_itemUnlockRequirements.TryGetValue(item, out var level))
+            return null;
+        return $"Complete {GetLevelDisplayName(level)} to unlock";
+    }
+
+    /// <summary>Returns the level name required to unlock this item, or null if always unlocked.</summary>
+    public static string? GetUnlockRequirement(ItemType item)
+    {
+        return _itemUnlockRequirements.TryGetValue(item, out var level) ? level : null;
+    }
+
+    /// <summary>Converts an internal level file name to a display name.</summary>
+    public static string GetLevelDisplayName(string levelName) => levelName switch
+    {
+        "TestLevel"  => "Level 1",
+        "TestLevel2" => "Level 2",
+        "TestLevel3" => "Level 3",
+        _            => levelName,
+    };
+
+    /// <summary>Loads unlock data from disk. Safe to call multiple times.</summary>
+    public static void Load()
+    {
+        _completedLevels = new HashSet<string>();
+        try
+        {
+            if (!File.Exists(SavePath)) return;
+            string json = File.ReadAllText(SavePath);
+            var raw = JsonSerializer.Deserialize<List<string>>(json);
+            if (raw != null)
+                _completedLevels = new HashSet<string>(raw);
+        }
+        catch { }
+    }
+
+    /// <summary>Records that a level has been completed and saves to disk.</summary>
+    public static void RecordLevelComplete(string levelName)
+    {
+        if (_completedLevels.Add(levelName))
+            Save();
+    }
+
+    /// <summary>Clears all unlock data from memory and disk (used for testing/reset).</summary>
+    public static void Reset()
+    {
+        _completedLevels = new HashSet<string>();
+        try { if (File.Exists(SavePath)) File.Delete(SavePath); } catch { }
+    }
+
+    private static void Save()
+    {
+        try
+        {
+            string? dir = Path.GetDirectoryName(SavePath);
+            if (dir != null && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(SavePath, JsonSerializer.Serialize(new List<string>(_completedLevels)));
+        }
+        catch { }
+    }
+}

--- a/src/PolyGone/Scenes/InventoryManagement.cs
+++ b/src/PolyGone/Scenes/InventoryManagement.cs
@@ -103,8 +103,8 @@ namespace PolyGone
             _levelFile = levelFile;
             previousKeyboardState = Keyboard.GetState();
             
-            // Initialize with last selected values
-            _selectedItems = new List<ItemType>(_lastSelectedItems);
+            // Initialize with last selected values, filtering out any that are now locked
+            _selectedItems = new List<ItemType>(_lastSelectedItems.FindAll(UnlockTracker.IsItemUnlocked));
             _selectedWeapon = _lastSelectedWeapon;
         }
 
@@ -186,13 +186,16 @@ namespace PolyGone
                     if (InputManager.IsLeftMouseButtonClicked())
                     {
                         ItemType selectedItem = _itemTypes[_itemCursor];
-                        if (_selectedItems.Contains(selectedItem))
+                        if (UnlockTracker.IsItemUnlocked(selectedItem))
                         {
-                            _selectedItems.Remove(selectedItem);
-                        }
-                        else if (_selectedItems.Count < 2)
-                        {
-                            _selectedItems.Add(selectedItem);
+                            if (_selectedItems.Contains(selectedItem))
+                            {
+                                _selectedItems.Remove(selectedItem);
+                            }
+                            else if (_selectedItems.Count < 2)
+                            {
+                                _selectedItems.Add(selectedItem);
+                            }
                         }
                         InputManager.ConsumeClick();
                     }
@@ -267,8 +270,12 @@ namespace PolyGone
             if (IsKeyPressed(Keys.Enter) || IsKeyPressed(Keys.Space))
             {
                 ItemType selectedItem = _itemTypes[_itemCursor];
-                
-                if (_selectedItems.Contains(selectedItem))
+
+                if (!UnlockTracker.IsItemUnlocked(selectedItem))
+                {
+                    // Item is locked — do nothing
+                }
+                else if (_selectedItems.Contains(selectedItem))
                 {
                     // Deselect item
                     _selectedItems.Remove(selectedItem);
@@ -346,6 +353,13 @@ namespace PolyGone
             }
         }
 
+        /// <summary>Clears the saved loadout so the next inventory screen starts fresh.</summary>
+        public static void ResetSavedLoadout()
+        {
+            _lastSelectedItems = new List<ItemType> { ItemType.DoubleJump, ItemType.SpeedBoost };
+            _lastSelectedWeapon = WeaponType.Blaster;
+        }
+
         private void StartGame()
         {
             // Save current selections for next time
@@ -411,21 +425,39 @@ namespace PolyGone
             for (int i = 0; i < _itemNames.Length; i++)
             {
                 string itemName = _itemNames[i];
-                bool isSelected = _selectedItems.Contains(_itemTypes[i]);
+                bool isUnlocked = UnlockTracker.IsItemUnlocked(_itemTypes[i]);
+                bool isSelected = isUnlocked && _selectedItems.Contains(_itemTypes[i]);
                 bool isCursor = i == _itemCursor && _currentMode == SelectionMode.Items;
 
-                Color color = isCursor ? Color.Yellow : (isSelected ? Color.Green : Color.White);
-                string prefix = isSelected ? "[X] " : "[ ] ";
+                Color color;
+                string prefix;
+                if (!isUnlocked)
+                {
+                    color = isCursor ? Color.Orange : Color.DarkGray;
+                    prefix = "[LOCKED] ";
+                }
+                else
+                {
+                    color = isCursor ? Color.Yellow : (isSelected ? Color.Green : Color.White);
+                    prefix = isSelected ? "[X] " : "[ ] ";
+                }
 
                 spriteBatch.DrawString(_font, prefix + itemName, new Vector2(startX, startY + i * 40), color);
             }
 
-            // Draw description for the currently highlighted item below the list
+            // Draw description (or unlock hint) for the currently highlighted item
             int descY = startY + _itemNames.Length * 40 + 10;
-            string activeItemDesc = _currentMode == SelectionMode.Items ? _itemDescriptions[_itemCursor] : "";
-            if (activeItemDesc.Length > 0)
+            if (_currentMode == SelectionMode.Items)
             {
-                spriteBatch.DrawString(_font, activeItemDesc, new Vector2(startX, descY), Color.LightGray);
+                bool cursorUnlocked = UnlockTracker.IsItemUnlocked(_itemTypes[_itemCursor]);
+                string activeItemDesc = cursorUnlocked
+                    ? _itemDescriptions[_itemCursor]
+                    : (UnlockTracker.GetUnlockHint(_itemTypes[_itemCursor]) ?? "");
+                if (activeItemDesc.Length > 0)
+                {
+                    Color descColor = cursorUnlocked ? Color.LightGray : Color.Orange;
+                    spriteBatch.DrawString(_font, activeItemDesc, new Vector2(startX, descY), descColor);
+                }
             }
         }
 

--- a/src/PolyGone/Scenes/LevelSelect.cs
+++ b/src/PolyGone/Scenes/LevelSelect.cs
@@ -64,11 +64,15 @@ namespace PolyGone
                     if (bounds.Contains(InputManager.GetMousePosition()))
                     {
                         _selectedIndex = i;
-                        
-                        // Mouse click with InputManager
+
+                        // Mouse click with InputManager — ignore locked levels
                         if (InputManager.IsLeftMouseButtonClicked())
                         {
-                            ExecuteSelection();
+                            string? lf = _levelFiles[i];
+                            if (lf == null || UnlockTracker.IsLevelUnlocked(lf))
+                            {
+                                ExecuteSelection();
+                            }
                             InputManager.ConsumeClick();
                         }
                     }
@@ -78,23 +82,51 @@ namespace PolyGone
             // Keyboard navigation
             if (IsKeyPressed(Keys.Up))
             {
-                _selectedIndex = (_selectedIndex - 1 + _levelNames.Length) % _levelNames.Length;
+                int next = (_selectedIndex - 1 + _levelNames.Length) % _levelNames.Length;
+                // Skip locked level entries
+                while (next != _selectedIndex)
+                {
+                    string? lf = _levelFiles[next];
+                    if (lf == null || UnlockTracker.IsLevelUnlocked(lf)) break;
+                    next = (next - 1 + _levelNames.Length) % _levelNames.Length;
+                }
+                _selectedIndex = next;
             }
 
             if (IsKeyPressed(Keys.Down))
             {
-                _selectedIndex = (_selectedIndex + 1) % _levelNames.Length;
+                int next = (_selectedIndex + 1) % _levelNames.Length;
+                // Skip locked level entries
+                while (next != _selectedIndex)
+                {
+                    string? lf = _levelFiles[next];
+                    if (lf == null || UnlockTracker.IsLevelUnlocked(lf)) break;
+                    next = (next + 1) % _levelNames.Length;
+                }
+                _selectedIndex = next;
             }
 
             if (IsKeyPressed(Keys.Enter))
             {
-                ExecuteSelection();
+                string? lf = _levelFiles[_selectedIndex];
+                if (lf == null || UnlockTracker.IsLevelUnlocked(lf))
+                    ExecuteSelection();
             }
 
             if (InputManager.IsEscapeKeyPressed())
             {
                 // Also allow Escape to go back
                 _sceneManager.PopScene(this);
+            }
+
+            // Ctrl+Shift+R: reset all unlock/progress data
+            bool ctrlHeld  = keyboardState.IsKeyDown(Keys.LeftControl)  || keyboardState.IsKeyDown(Keys.RightControl);
+            bool shiftHeld = keyboardState.IsKeyDown(Keys.LeftShift)    || keyboardState.IsKeyDown(Keys.RightShift);
+            if (ctrlHeld && shiftHeld && IsKeyPressed(Keys.R))
+            {
+                UnlockTracker.Reset();
+                InventoryManagement.ResetSavedLoadout();
+                _selectedIndex = 0;
             }
 
             previousKeyboardState = keyboardState;
@@ -155,15 +187,36 @@ namespace PolyGone
 
                 // Draw level options
                 var startY = viewport.Height / 2f - _levelNames.Length * 40f / 2f;
+                string? hintText = null;
 
                 for (var i = 0; i < _levelNames.Length; i++)
                 {
-                    var levelName = _levelNames[i];
-                    var color = i == _selectedIndex ? Color.Yellow : Color.White;
-                    var textSize = _font.MeasureString(levelName);
-                    var position = new Vector2(viewport.Width / 2f - textSize.X / 2f, startY + i * 40f);
+                    string? lf = _levelFiles[i];
+                    bool isLocked = lf != null && !UnlockTracker.IsLevelUnlocked(lf);
+                    bool isCursor = i == _selectedIndex;
 
-                    spriteBatch.DrawString(_font, levelName, position, color);
+                    string displayName = isLocked ? "[LOCKED] " + _levelNames[i] : _levelNames[i];
+                    Color color;
+                    if (isLocked)
+                        color = isCursor ? Color.Orange : Color.DarkGray;
+                    else
+                        color = isCursor ? Color.Yellow : Color.White;
+
+                    var textSize = _font.MeasureString(displayName);
+                    var position = new Vector2(viewport.Width / 2f - textSize.X / 2f, startY + i * 40f);
+                    spriteBatch.DrawString(_font, displayName, position, color);
+
+                    if (isCursor && isLocked)
+                        hintText = UnlockTracker.GetLevelUnlockHint(lf!);
+                }
+
+                // Show unlock hint below the list when a locked level is highlighted
+                if (hintText != null)
+                {
+                    var hintSize = _font.MeasureString(hintText);
+                    var hintPos = new Vector2(viewport.Width / 2f - hintSize.X / 2f,
+                        startY + _levelNames.Length * 40f + 10f);
+                    spriteBatch.DrawString(_font, hintText, hintPos, Color.Orange);
                 }
             }
         }

--- a/src/PolyGone/Scenes/WinScene.cs
+++ b/src/PolyGone/Scenes/WinScene.cs
@@ -46,6 +46,9 @@ public class WinScene : IScene
         
         previousKeyboardState = Keyboard.GetState();
         selectedIndex = 0;
+
+        // Record this level as completed so locked items can be unlocked
+        UnlockTracker.RecordLevelComplete(currentLevel);
     }
 
     public void Load()


### PR DESCRIPTION
Issue: #74 
Beating a level unlocks the next. Beating certain levels unlocks some items. `ctrl + shift + R` will reset level and item progress. Will be replaced with option selection when options are implemented. 